### PR TITLE
kinematic_equations() returns [0, 0, 0] explicitly when speeds == [0,…

### DIFF
--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -1,3 +1,4 @@
+
 from __future__ import print_function, division
 
 from sympy.core.backend import (sympify, diff, sin, cos, Matrix, symbols,
@@ -267,6 +268,8 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
         raise TypeError('Need to supply speeds in a list')
     if len(speeds) != 3:
         raise TypeError('Need to supply 3 body-fixed speeds')
+    if set(speeds) == set([0, 0, 0]): # All speeds equal to 0 should result in [0, 0, 0]
+        return [0, 0, 0]
     if not isinstance(coords, (list, tuple)):
         raise TypeError('Need to supply coordinates in a list')
     if rot_type.lower() in ['body', 'space']:


### PR DESCRIPTION
… 0, 0,]. This change coincides with issue #12600 .

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
#12600